### PR TITLE
allow resubscribe and restart_subscription_based_autoresponders to be set

### DIFF
--- a/lib/ex_campaign_monitor/subscriber.ex
+++ b/lib/ex_campaign_monitor/subscriber.ex
@@ -1,5 +1,13 @@
 defmodule ExCampaignMonitor.Subscriber do
-  defstruct [:email, :name, :custom_fields, :consent_to_track, :state]
+  defstruct [
+    :email, 
+    :name, 
+    :custom_fields, 
+    :consent_to_track, 
+    :state,
+    :resubscribe,
+    :restart_subscription_based_autoresponders
+  ]
 
   @doc """
   Create a new subscriber struct
@@ -28,13 +36,22 @@ defmodule ExCampaignMonitor.Subscriber do
   end
 
   def to_cm(subscriber) do
-    params = Map.take(subscriber, [:email, :name, :custom_fields, :consent_to_track])
+    params = Map.take(subscriber, [
+      :email, 
+      :name, 
+      :custom_fields, 
+      :consent_to_track, 
+      :resubscribe, 
+      :restart_subscription_based_autoresponders
+    ])
 
     %{
       "EmailAddress" => params[:email],
       "ConsentToTrack" => params[:consent_to_track],
       "Name" => params[:name],
-      "CustomFields" => convert_keys(params[:custom_fields], &key_to_string/1)
+      "CustomFields" => convert_keys(params[:custom_fields], &key_to_string/1),
+      "Resubscribe" => params[:resubscribe],
+      "RestartSubscriptionBasedAutoresponders" => params[:restart_subscription_based_autoresponders]
     }
     |> Enum.filter(fn {_, v} -> v != nil end)
     |> Enum.into(%{})

--- a/test/ex_campaign_monitor/subscriber_test.exs
+++ b/test/ex_campaign_monitor/subscriber_test.exs
@@ -65,7 +65,9 @@ defmodule ExCampaignMonitorTest.SubscriberTest do
                email: "jack@jackmarchant.com",
                consent_to_track: "No",
                name: "Jack Marchant",
-               custom_fields: custom_fields
+               custom_fields: custom_fields,
+               resubscribe: true,
+               restart_subscription_based_autoresponders: false
              }) == %{
                "EmailAddress" => "jack@jackmarchant.com",
                "ConsentToTrack" => "No",
@@ -79,7 +81,9 @@ defmodule ExCampaignMonitorTest.SubscriberTest do
                    "Key" => "interests",
                    "Value" => "Elixir"
                  }
-               ]
+               ],
+               "Resubscribe" => true,
+               "RestartSubscriptionBasedAutoresponders" => false
              }
     end
   end


### PR DESCRIPTION
Fixes https://github.com/jackmarchant/ex_campaign_monitor/issues/32