### PR TITLE
Decode json safely

### DIFF
--- a/lib/ex_campaign_monitor/transport.ex
+++ b/lib/ex_campaign_monitor/transport.ex
@@ -23,9 +23,12 @@ defmodule ExCampaignMonitor.Transport do
   when status_code in 200..299, do: {:ok, ""}
   defp process_response({:ok, %HTTPoison.Response{body: body, status_code: status_code}})
   when status_code in 200..299, do: {:ok, Jason.decode!(body)}
-  defp process_response({:ok, %HTTPoison.Response{body: body}}),
-    do: {:error, Jason.decode!(body)["Message"]}
-
+  defp process_response({:ok, %HTTPoison.Response{body: body}}) do
+    case Jason.decode(body) do
+      {:ok, body} -> {:error, body["Message"]}
+      {:error, _} -> {:error, body}
+    end
+  end
   defp process_response({:error, %HTTPoison.Error{reason: reason}}), do: {:error, reason}
 
   defp token do


### PR DESCRIPTION
When a non-json response is returned the transport module would raise an error. Instead it should return an error tuple